### PR TITLE
Fix dependency entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "request": "^2.65.0",
-    "slack-terminalize": "file:///Users/gnramesh/Documents/dev/personal/slack-terminalize"
+    "slack-terminalize": "^1.0.0"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
The entry for slack-terminalize was pointing at a local path, so I've updated it to reference the current version from npm.
